### PR TITLE
Add missing directory recurse in workloads ApplicationSet

### DIFF
--- a/argocd/iac/terraform/examples/eks/multi-cluster/hub-spoke/hub/bootstrap/workloads.yaml
+++ b/argocd/iac/terraform/examples/eks/multi-cluster/hub-spoke/hub/bootstrap/workloads.yaml
@@ -25,6 +25,9 @@ spec:
         repoURL: '{{metadata.annotations.workload_repo_url}}'
         path: '{{metadata.annotations.workload_repo_basepath}}{{metadata.annotations.workload_repo_path}}'
         targetRevision: '{{metadata.annotations.workload_repo_revision}}'
+        directory:
+          recurse: true
+          exclude: exclude/*
       destination:
         namespace: 'workload'
         name: '{{name}}'


### PR DESCRIPTION
Because the `apps` folder usually contains subfolders like this:
https://github.com/gitops-bridge-dev/kubecon-2023-na-argocon/tree/main/gitops/apps

Without the `recurse` the applications will not be created.