### PR TITLE
Enable EKS Pod Identity for Hub-Spoke Patterns

### DIFF
--- a/argocd/iac/terraform/examples/eks/multi-cluster/hub-spoke-shared/README.md
+++ b/argocd/iac/terraform/examples/eks/multi-cluster/hub-spoke-shared/README.md
@@ -50,16 +50,6 @@ Access ArgoCD's UI, run the command from the output:
 terraform output -raw access_argocd
 ```
 
-## Verify that ArgoCD Service Accouts has the annotation for IRSA
-```shell
-kubectl get sa -n argocd argocd-application-controller -o json | jq '.metadata.annotations."eks.amazonaws.com/role-arn"'
-kubectl get sa -n argocd argocd-server  -o json | jq '.metadata.annotations."eks.amazonaws.com/role-arn"'
-```
-The output should match the `arn` for the IAM Role that will assume the IAM Role in spoke/remote clusters
-```text
-"arn:aws:iam::0123456789:role/hub-spoke-control-plane-argocd-hub"
-```
-
 ## Deploy the Spoke EKS Cluster
 Initialize Terraform and deploy the EKS clusters:
 Is recommended to use a new terminal window for each cluster

--- a/argocd/iac/terraform/examples/eks/multi-cluster/hub-spoke-shared/hub/outputs.tf
+++ b/argocd/iac/terraform/examples/eks/multi-cluster/hub-spoke-shared/hub/outputs.tf
@@ -36,8 +36,9 @@ output "access_argocd" {
 
 output "argocd_iam_role_arn" {
   description = "IAM Role for ArgoCD Cluster Hub, use to connect to spoke clusters"
-  value       = module.argocd_irsa.iam_role_arn
+  value       = aws_iam_role.argocd_hub.arn
 }
+
 
 output "cluster_name" {
   description = "Cluster Hub name"

--- a/argocd/iac/terraform/examples/eks/multi-cluster/hub-spoke-shared/hub/variables.tf
+++ b/argocd/iac/terraform/examples/eks/multi-cluster/hub-spoke-shared/hub/variables.tf
@@ -11,7 +11,7 @@ variable "region" {
 variable "kubernetes_version" {
   description = "Kubernetes version"
   type        = string
-  default     = "1.28"
+  default     = "1.29"
 }
 variable "addons" {
   description = "Kubernetes addons"
@@ -19,10 +19,7 @@ variable "addons" {
   default = {
     enable_aws_load_balancer_controller = true
     enable_metrics_server               = true
-    # Enable argocd with IRSA
-    enable_aws_argocd = true
-    # Disable argocd without IRSA
-    enable_argocd = false
+    enable_argocd = true
   }
 }
 # Addons Git

--- a/argocd/iac/terraform/examples/eks/multi-cluster/hub-spoke-shared/hub/versions.tf
+++ b/argocd/iac/terraform/examples/eks/multi-cluster/hub-spoke-shared/hub/versions.tf
@@ -4,15 +4,15 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.67.0"
+      version = ">= 5.39.1"
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 2.10.1"
+      version = ">= 2.12.1"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "2.22.0"
+      version = ">= 2.26.0"
     }
   }
 

--- a/argocd/iac/terraform/examples/eks/multi-cluster/hub-spoke-shared/spokes/versions.tf
+++ b/argocd/iac/terraform/examples/eks/multi-cluster/hub-spoke-shared/spokes/versions.tf
@@ -4,19 +4,19 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.67.0"
-    }
-    helm = {
-      source  = "hashicorp/helm"
-      version = ">= 2.10.1"
+      version = ">= 5.39.1"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "2.22.0"
+      version = ">= 2.26.0"
+    }
+    helm = {
+      source  = "hashicorp/helm"
+      version = ">= 2.12.1"
     }
     time = {
       source  = "hashicorp/time"
-      version = ">= 0.9.1"
+      version = ">= 0.10.0"
     }
   }
 

--- a/argocd/iac/terraform/examples/eks/multi-cluster/hub-spoke-shared/spokes/workspaces/dev.tfvars
+++ b/argocd/iac/terraform/examples/eks/multi-cluster/hub-spoke-shared/spokes/workspaces/dev.tfvars
@@ -1,6 +1,6 @@
 vpc_cidr = "10.1.0.0/16"
 region = "us-west-2"
-kubernetes_version = "1.28"
+kubernetes_version = "1.29"
 addons = {
   enable_aws_load_balancer_controller = true
   enable_metrics_server               = true

--- a/argocd/iac/terraform/examples/eks/multi-cluster/hub-spoke-shared/spokes/workspaces/prod.tfvars
+++ b/argocd/iac/terraform/examples/eks/multi-cluster/hub-spoke-shared/spokes/workspaces/prod.tfvars
@@ -1,6 +1,6 @@
 vpc_cidr = "10.3.0.0/16"
 region = "us-west-2"
-kubernetes_version = "1.28"
+kubernetes_version = "1.29"
 addons = {
   enable_aws_load_balancer_controller = true
   enable_metrics_server               = true

--- a/argocd/iac/terraform/examples/eks/multi-cluster/hub-spoke-shared/spokes/workspaces/staging.tfvars
+++ b/argocd/iac/terraform/examples/eks/multi-cluster/hub-spoke-shared/spokes/workspaces/staging.tfvars
@@ -1,6 +1,6 @@
 vpc_cidr = "10.2.0.0/16"
 region = "us-west-2"
-kubernetes_version = "1.28"
+kubernetes_version = "1.29"
 addons = {
   enable_aws_load_balancer_controller = true
   enable_metrics_server               = true

--- a/argocd/iac/terraform/examples/eks/multi-cluster/hub-spoke/README.md
+++ b/argocd/iac/terraform/examples/eks/multi-cluster/hub-spoke/README.md
@@ -50,16 +50,6 @@ Access ArgoCD's UI, run the command from the output:
 terraform output -raw access_argocd
 ```
 
-## Verify that ArgoCD Service Accouts has the annotation for IRSA
-```shell
-kubectl get sa -n argocd argocd-application-controller -o json | jq '.metadata.annotations."eks.amazonaws.com/role-arn"'
-kubectl get sa -n argocd argocd-server  -o json | jq '.metadata.annotations."eks.amazonaws.com/role-arn"'
-```
-The output should match the `arn` for the IAM Role that will assume the IAM Role in spoke/remote clusters
-```text
-"arn:aws:iam::0123456789:role/hub-spoke-control-plane-argocd-hub"
-```
-
 ## Deploy the Spoke EKS Cluster
 Initialize Terraform and deploy the EKS clusters:
 ```shell

--- a/argocd/iac/terraform/examples/eks/multi-cluster/hub-spoke/hub/main.tf
+++ b/argocd/iac/terraform/examples/eks/multi-cluster/hub-spoke/hub/main.tf
@@ -73,10 +73,9 @@ locals {
     enable_ack_emrcontainers                     = try(var.addons.enable_ack_emrcontainers, false)
     enable_ack_sfn                               = try(var.addons.enable_ack_sfn, false)
     enable_ack_eventbridge                       = try(var.addons.enable_ack_eventbridge, false)
-    enable_aws_argocd                            = try(var.addons.enable_aws_argocd, false)
   }
   oss_addons = {
-    enable_argocd                          = try(var.addons.enable_argocd, false)
+    enable_argocd                          = try(var.addons.enable_argocd, true)
     enable_argo_rollouts                   = try(var.addons.enable_argo_rollouts, false)
     enable_argo_events                     = try(var.addons.enable_argo_events, false)
     enable_argo_workflows                  = try(var.addons.enable_argo_workflows, false)
@@ -107,7 +106,6 @@ locals {
       aws_vpc_id       = module.vpc.vpc_id
     },
     {
-      argocd_iam_role_arn = module.argocd_irsa.iam_role_arn
       argocd_namespace    = local.argocd_namespace
     },
     {
@@ -150,42 +148,48 @@ module "gitops_bridge_bootstrap" {
 ################################################################################
 # ArgoCD EKS Access
 ################################################################################
-module "argocd_irsa" {
-  source = "aws-ia/eks-blueprints-addon/aws"
-
-  create_release             = false
-  create_role                = true
-  role_name_use_prefix       = false
-  role_name                  = "${module.eks.cluster_name}-argocd-hub"
-  assume_role_condition_test = "StringLike"
-  create_policy              = false
-  role_policies = {
-    ArgoCD_EKS_Policy = aws_iam_policy.irsa_policy.arn
-  }
-  oidc_providers = {
-    this = {
-      provider_arn    = module.eks.oidc_provider_arn
-      namespace       = local.argocd_namespace
-      service_account = "argocd-*"
+data "aws_iam_policy_document" "eks_assume" {
+  statement {
+    effect = "Allow"
+    principals {
+      type        = "Service"
+      identifiers = ["pods.eks.amazonaws.com"]
     }
+    actions = ["sts:AssumeRole","sts:TagSession"]
   }
-  tags = local.tags
-
 }
-
-resource "aws_iam_policy" "irsa_policy" {
-  name        = "${module.eks.cluster_name}-argocd-irsa"
-  description = "IAM Policy for ArgoCD Hub"
-  policy      = data.aws_iam_policy_document.irsa_policy.json
-  tags        = local.tags
+resource "aws_iam_role" "argocd_hub" {
+  name               = "${module.eks.cluster_name}-argocd-hub"
+  assume_role_policy = data.aws_iam_policy_document.eks_assume.json
 }
-
-data "aws_iam_policy_document" "irsa_policy" {
+data "aws_iam_policy_document" "aws_assume_policy" {
   statement {
     effect    = "Allow"
     resources = ["*"]
-    actions   = ["sts:AssumeRole"]
+    actions   = ["sts:AssumeRole","sts:TagSession"]
   }
+}
+resource "aws_iam_policy" "aws_assume_policy" {
+  name        = "${module.eks.cluster_name}-argocd-aws-assume"
+  description = "IAM Policy for ArgoCD Hub"
+  policy      = data.aws_iam_policy_document.aws_assume_policy.json
+  tags        = local.tags
+}
+resource "aws_iam_role_policy_attachment" "aws_assume_policy" {
+  role       = aws_iam_role.argocd_hub.name
+  policy_arn = aws_iam_policy.aws_assume_policy.arn
+}
+resource "aws_eks_pod_identity_association" "argocd_app_controller" {
+  cluster_name    = module.eks.cluster_name
+  namespace       = "argocd"
+  service_account = "argocd-application-controller"
+  role_arn        = aws_iam_role.argocd_hub.arn
+}
+resource "aws_eks_pod_identity_association" "argocd_api_server" {
+  cluster_name    = module.eks.cluster_name
+  namespace       = "argocd"
+  service_account = "argocd-server"
+  role_arn        = aws_iam_role.argocd_hub.arn
 }
 
 ################################################################################
@@ -229,7 +233,7 @@ module "eks_blueprints_addons" {
 #tfsec:ignore:aws-eks-enable-control-plane-logging
 module "eks" {
   source  = "terraform-aws-modules/eks/aws"
-  version = "~> 19.13"
+  version = "~> 20.5"
 
   cluster_name                   = local.name
   cluster_version                = local.cluster_version
@@ -238,6 +242,10 @@ module "eks" {
 
   vpc_id     = module.vpc.vpc_id
   subnet_ids = module.vpc.private_subnets
+
+  # Cluster access entry
+  # To add the current caller identity as an administrator
+  enable_cluster_creator_admin_permissions = true
 
   eks_managed_node_groups = {
     initial = {
@@ -250,6 +258,9 @@ module "eks" {
   }
   # EKS Addons
   cluster_addons = {
+    eks-pod-identity-agent = {
+      most_recent = true
+    }
     vpc-cni = {
       # Specify the VPC CNI addon should be deployed before compute to ensure
       # the addon is configured before data plane compute resources are created

--- a/argocd/iac/terraform/examples/eks/multi-cluster/hub-spoke/hub/outputs.tf
+++ b/argocd/iac/terraform/examples/eks/multi-cluster/hub-spoke/hub/outputs.tf
@@ -36,8 +36,9 @@ output "access_argocd" {
 
 output "argocd_iam_role_arn" {
   description = "IAM Role for ArgoCD Cluster Hub, use to connect to spoke clusters"
-  value       = module.argocd_irsa.iam_role_arn
+  value       = aws_iam_role.argocd_hub.arn
 }
+
 
 output "cluster_name" {
   description = "Cluster Hub name"

--- a/argocd/iac/terraform/examples/eks/multi-cluster/hub-spoke/hub/variables.tf
+++ b/argocd/iac/terraform/examples/eks/multi-cluster/hub-spoke/hub/variables.tf
@@ -11,7 +11,7 @@ variable "region" {
 variable "kubernetes_version" {
   description = "Kubernetes version"
   type        = string
-  default     = "1.28"
+  default     = "1.29"
 }
 variable "addons" {
   description = "Kubernetes addons"
@@ -19,10 +19,7 @@ variable "addons" {
   default = {
     enable_aws_load_balancer_controller = true
     enable_metrics_server               = true
-    # Enable argocd with IRSA
-    enable_aws_argocd = true
-    # Disable argocd without IRSA
-    enable_argocd = false
+    enable_argocd = true
   }
 }
 # Addons Git

--- a/argocd/iac/terraform/examples/eks/multi-cluster/hub-spoke/hub/versions.tf
+++ b/argocd/iac/terraform/examples/eks/multi-cluster/hub-spoke/hub/versions.tf
@@ -4,15 +4,15 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.67.0"
+      version = ">= 5.39.1"
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 2.10.1"
+      version = ">= 2.12.1"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "2.22.0"
+      version = ">= 2.26.0"
     }
   }
 

--- a/argocd/iac/terraform/examples/eks/multi-cluster/hub-spoke/spokes/versions.tf
+++ b/argocd/iac/terraform/examples/eks/multi-cluster/hub-spoke/spokes/versions.tf
@@ -4,11 +4,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.67.0"
+      version = ">= 5.39.1"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "2.22.0"
+      version = ">= 2.26.0"
     }
   }
 

--- a/argocd/iac/terraform/examples/eks/multi-cluster/hub-spoke/spokes/workspaces/dev.tfvars
+++ b/argocd/iac/terraform/examples/eks/multi-cluster/hub-spoke/spokes/workspaces/dev.tfvars
@@ -1,10 +1,9 @@
 vpc_cidr = "10.1.0.0/16"
 region = "us-west-2"
-kubernetes_version = "1.28"
+kubernetes_version = "1.29"
 addons = {
   enable_aws_load_balancer_controller = true
   enable_metrics_server               = true
   # Disable argocd on spoke clusters
-  enable_aws_argocd = false
   enable_argocd = false
 }

--- a/argocd/iac/terraform/examples/eks/multi-cluster/hub-spoke/spokes/workspaces/prod.tfvars
+++ b/argocd/iac/terraform/examples/eks/multi-cluster/hub-spoke/spokes/workspaces/prod.tfvars
@@ -1,10 +1,9 @@
 vpc_cidr = "10.3.0.0/16"
 region = "us-west-2"
-kubernetes_version = "1.28"
+kubernetes_version = "1.29"
 addons = {
   enable_aws_load_balancer_controller = true
   enable_metrics_server               = true
   # Disable argocd on spoke clusters
-  enable_aws_argocd = false
   enable_argocd = false
 }

--- a/argocd/iac/terraform/examples/eks/multi-cluster/hub-spoke/spokes/workspaces/staging.tfvars
+++ b/argocd/iac/terraform/examples/eks/multi-cluster/hub-spoke/spokes/workspaces/staging.tfvars
@@ -1,10 +1,9 @@
 vpc_cidr = "10.2.0.0/16"
 region = "us-west-2"
-kubernetes_version = "1.28"
+kubernetes_version = "1.29"
 addons = {
   enable_aws_load_balancer_controller = true
   enable_metrics_server               = true
   # Disable argocd on spoke clusters
-  enable_aws_argocd = false
   enable_argocd = false
 }


### PR DESCRIPTION
ArgoCD 2.10.2 added EKS Pod Identity support for ArgoCD.
This means a central ArgoCD can assume an IAM Role without IRSA annotation, this would be done with EKS Pod Identity access

Related to #42 
Closes #56