### PR TITLE
Typo on creating kube secrets for private repos

### DIFF
--- a/argocd/iac/terraform/examples/eks/private-git/main.tf
+++ b/argocd/iac/terraform/examples/eks/private-git/main.tf
@@ -151,12 +151,12 @@ resource "kubernetes_secret" "git_secrets" {
   for_each = {
     git-addons = {
       type          = "git"
-      url           = local.gitops_addons_org
+      url           = local.gitops_addons_url
       sshPrivateKey = file(pathexpand(local.git_private_ssh_key))
     }
     git-workloads = {
       type          = "git"
-      url           = local.gitops_workload_org
+      url           = local.gitops_workload_url
       sshPrivateKey = file(pathexpand(local.git_private_ssh_key))
     }
   }


### PR DESCRIPTION
Once I've changed org to url,  everything started working correctly in my private repo.

```hcl
resource "kubernetes_secret" "git_secrets" {
  depends_on = [kubernetes_namespace.argocd]
  for_each = {
    git-addons = {
      type          = "git"
      url           = local.gitops_addons_url
      sshPrivateKey = file(pathexpand(local.git_private_ssh_key))
    }
    git-workloads = {
      type          = "git"
      url           = local.gitops_workload_url
      sshPrivateKey = file(pathexpand(local.git_private_ssh_key))
    }
  }
```